### PR TITLE
chore: 🔧 Make pushes on patches cancel previous workflows.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
  flake8:


### PR DESCRIPTION
- saves time and CPU power computing stale results.