### PR TITLE
feat: Add support for django 41

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ classifiers = [
     "Framework :: Django :: 3.0",
     "Framework :: Django :: 3.1",
     "Framework :: Django :: 3.2",
+    "Framework :: Django :: 4.0",
+    "Framework :: Django :: 4.1",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",

--- a/tox.ini
+++ b/tox.ini
@@ -2,10 +2,10 @@
 isolated_build = True
 envlist =
     py37-dj{22, 30, 31, 32}
-    py38-dj{22, 30, 31, 32, 40, main}
-    py39-dj{22, 30, 31, 32, 40, main}
-    py310-dj{40, main}
-    py311-dj{40, main}
+    py38-dj{22, 30, 31, 32, 40, 41, main}
+    py39-dj{22, 30, 31, 32, 40, 41, main}
+    py310-dj{40, 41, main}
+    py311-dj{40, 41, main}
     lint, docs
 
 [gh-actions]
@@ -43,6 +43,7 @@ deps =
     dj31: Django>=3.1,<3.2
     dj32: Django>=3.2,<3.3
     dj40: Django>=4.0,<4.1
+    dj41: Django>=4.1,<4.2
     djmain: https://github.com/django/django/archive/main.tar.gz
 
 commands =


### PR DESCRIPTION
- also show that django 40 is also supported on PyPI.
  although, it was already supported, but the same wasn't
  change in the classifiers for PyPI.